### PR TITLE
Fix up fips integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,3 +159,16 @@ jobs:
     - if: "!startsWith(matrix.os, 'windows')"
       run: cargo test
       name: Run tests (not Windows)
+
+  test-fips:
+    name: Test FIPS integration
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - name: Install Rust (rustup)
+      run: rustup update stable --no-self-update && rustup default stable
+      shell: bash
+    - run: cargo test --features fips
+      name: Run tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = boring-sys/deps/boringssl
 	url = https://github.com/google/boringssl.git
 	ignore = dirty
+[submodule "boring-sys/deps/boringssl-fips"]
+	path = boring-sys/deps/boringssl-fips
+	url = https://github.com/google/boringssl.git

--- a/README.md
+++ b/README.md
@@ -29,18 +29,9 @@ certified with [certificate
 3678](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3678)
 is supported by this crate. Support is enabled by this crate's `fips-3678` feature.
 
-You must provide and build your own FIPS-validated module in order for this
-crate to link against it (see the installation instructions in the
-[BoringCrypto FIPS 140-2 Non-Proprietary Security Policy] (https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp3678.pdf)
-).
-
-After building the FIPS-validated module, you must build this crate with the
-`BORING_BSSL_PATH`, `BORING_BSSL_INCLUDE_PATH`, and maybe the
-`BORING_BSSL_LIB_PATH`. Once built, the `fips_enabled` example can be used to
-test that `boring` is running in FIPS mode:
+`boring-sys` comes with a test that FIPS is enabled/disabled depending on the feature flag. You can run it as follows:
 ```bash
-$ cargo run --features fips-3678 --example fips_enabled
-boring::fips::enabled(): true
+$ cargo test --features fips-3678 fips::enabled
 ```
 
 ## Contribution

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ certified with [certificate
 is supported by this crate. Support is enabled by this crate's `fips-3678` feature.
 
 You must provide and build your own FIPS-validated module in order for this
-crate to link against it (see the instalation instructions in the
+crate to link against it (see the installation instructions in the
 [BoringCrypto FIPS 140-2 Non-Proprietary Security Policy] (https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp3678.pdf)
 ).
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ _Warning_: When providing a different version of BoringSSL make sure to use a co
 Only BoringCrypto module version ae223d6138807a13006342edfeef32e813246b39, as
 certified with [certificate
 3678](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3678)
-is supported by this crate. Support is enabled by this crate's `fips-3678` feature.
+is supported by this crate. Support is enabled by this crate's `fips` feature.
 
 `boring-sys` comes with a test that FIPS is enabled/disabled depending on the feature flag. You can run it as follows:
 ```bash
-$ cargo test --features fips-3678 fips::enabled
+$ cargo test --features fips fips::is_enabled
 ```
 
 ## Contribution

--- a/boring-sys/Cargo.toml
+++ b/boring-sys/Cargo.toml
@@ -31,6 +31,5 @@ bindgen = "0.59"
 cmake = "0.1"
 
 [features]
-fips-3678 = ["fips"]
-# The "fips" feature is used for conditional-compilation that is common to all supported FIPS-validated versions
+# Use a FIPS-validated version of boringssl.
 fips = []

--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -105,6 +105,7 @@ fn get_boringssl_cmake_config() -> cmake::Config {
             };
 
             // We need ANDROID_NDK_HOME to be set properly.
+            println!("cargo:rerun-if-env-changed=ANDROID_NDK_HOME");
             let android_ndk_home = std::env::var("ANDROID_NDK_HOME")
                 .expect("Please set ANDROID_NDK_HOME for Android build");
             let android_ndk_home = std::path::Path::new(&android_ndk_home);

--- a/boring/Cargo.toml
+++ b/boring/Cargo.toml
@@ -23,6 +23,5 @@ hex = "0.4"
 rusty-hook = "^0.11"
 
 [features]
-fips-3678 = ["fips", "boring-sys/fips-3678"]
-# The "fips" feature is used for conditional-compilation that is common to all supported FIPS-validated versions
+# Use a FIPS-validated version of boringssl.
 fips = ["boring-sys/fips"]

--- a/boring/src/fips.rs
+++ b/boring/src/fips.rs
@@ -21,13 +21,10 @@ pub fn enabled() -> bool {
     unsafe { ffi::FIPS_mode() != 0 }
 }
 
-#[cfg(test)]
-mod test {
-    #[test]
-    fn is_enabled() {
-        #[cfg(feature = "fips")]
-        assert!(super::enabled());
-        #[cfg(not(feature = "fips"))]
-        assert!(!super::enabled());
-    }
+#[test]
+fn is_enabled() {
+    #[cfg(feature = "fips")]
+    assert!(enabled());
+    #[cfg(not(feature = "fips"))]
+    assert!(!enabled());
 }

--- a/boring/src/fips.rs
+++ b/boring/src/fips.rs
@@ -20,3 +20,11 @@ pub fn enable(enabled: bool) -> Result<(), ErrorStack> {
 pub fn enabled() -> bool {
     unsafe { ffi::FIPS_mode() != 0 }
 }
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn is_enabled() {
+        assert!(super::enabled());
+    }
+}

--- a/boring/src/fips.rs
+++ b/boring/src/fips.rs
@@ -25,6 +25,9 @@ pub fn enabled() -> bool {
 mod test {
     #[test]
     fn is_enabled() {
+        #[cfg(feature = "fips")]
         assert!(super::enabled());
+        #[cfg(not(feature = "fips"))]
+        assert!(!super::enabled());
     }
 }

--- a/boring/src/x509/mod.rs
+++ b/boring/src/x509/mod.rs
@@ -230,26 +230,14 @@ impl X509Builder {
 
     /// Sets the notAfter constraint on the certificate.
     pub fn set_not_after(&mut self, not_after: &Asn1TimeRef) -> Result<(), ErrorStack> {
-        #[cfg(feature = "fips")]
-        unsafe {
-            cvt(X509_set_notAfter(self.0.as_ptr(), not_after.as_ptr())).map(|_| ())
-        }
-        #[cfg(not(feature = "fips"))]
-        unsafe {
-            cvt(X509_set1_notAfter(self.0.as_ptr(), not_after.as_ptr())).map(|_| ())
-        }
+        // TODO: once FIPS supports `set1_notAfter`, use that instead
+        unsafe { cvt(X509_set_notAfter(self.0.as_ptr(), not_after.as_ptr())).map(|_| ()) }
     }
 
     /// Sets the notBefore constraint on the certificate.
     pub fn set_not_before(&mut self, not_before: &Asn1TimeRef) -> Result<(), ErrorStack> {
-        #[cfg(feature = "fips")]
-        unsafe {
-            cvt(X509_set_notBefore(self.0.as_ptr(), not_before.as_ptr())).map(|_| ())
-        }
-        #[cfg(not(feature = "fips"))]
-        unsafe {
-            cvt(X509_set1_notBefore(self.0.as_ptr(), not_before.as_ptr())).map(|_| ())
-        }
+        // TODO: once FIPS supports `set1_notBefore`, use that instead
+        unsafe { cvt(X509_set_notBefore(self.0.as_ptr(), not_before.as_ptr())).map(|_| ()) }
     }
 
     /// Sets the version of the certificate.
@@ -1420,16 +1408,10 @@ impl Stackable for X509Object {
 
 use crate::ffi::{X509_get0_notAfter, X509_get0_notBefore, X509_get0_signature, X509_up_ref};
 
-use crate::ffi::{ASN1_STRING_get0_data, X509_ALGOR_get0};
-#[cfg(not(feature = "fips"))]
-use crate::ffi::{
-    X509_REQ_get_subject_name, X509_REQ_get_version, X509_STORE_CTX_get0_chain, X509_set1_notAfter,
-    X509_set1_notBefore,
-};
-#[cfg(feature = "fips")]
-use crate::ffi::{X509_set_notAfter, X509_set_notBefore};
-
 use crate::ffi::X509_OBJECT_get0_X509;
+use crate::ffi::{ASN1_STRING_get0_data, X509_ALGOR_get0, X509_set_notAfter, X509_set_notBefore};
+#[cfg(not(feature = "fips"))]
+use crate::ffi::{X509_REQ_get_subject_name, X509_REQ_get_version, X509_STORE_CTX_get0_chain};
 
 #[allow(bad_style)]
 unsafe fn X509_OBJECT_free(x: *mut ffi::X509_OBJECT) {

--- a/hyper-boring/Cargo.toml
+++ b/hyper-boring/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["test/*"]
 default = ["runtime"]
 
 runtime = ["hyper/runtime"]
-fips-3678 = ["tokio-boring/fips-3678"]
+fips = ["tokio-boring/fips"]
 
 [dependencies]
 antidote = "1.0.0"

--- a/tokio-boring/Cargo.toml
+++ b/tokio-boring/Cargo.toml
@@ -22,4 +22,4 @@ tokio = { version = "1", features = ["full"] }
 anyhow = "1"
 
 [features]
-fips-3678 = ["boring/fips-3678"]
+fips = ["boring/fips"]


### PR DESCRIPTION
The git history for this is kind of a mess, I can clean it up if you like.

This primarily does the following things:
- Build boringssl from source instead of requiring a pre-built version
- Adds an automated test to make sure that fips is always enabled when the feature is set
- Enforces in the build script that a supported version of clang is used to build boringssl when fips is enabled
- Adds a new boringssl-fips submodule, since `git submodule` only allows having one canonical commit checked-in per submodule

It also makes some minor cleanups:
- Fix tests that were broken with `--feature fips`
- Adds a CI job for testing with `--feature fips` enabled
- Fixes some hard-coded paths to match the source code layout in the older boringssl version
- Uses `X509_set_notBefore` unconditionally rather than only when fips is enabled

I removed the `BORING_BSSL_INCLUDE_PATH` support because it was a little tricky to get to work properly with FIPS and it should be possible to fix independently anyway.

cc @cjmakes